### PR TITLE
デプロイのフォロー機能修正3

### DIFF
--- a/database/migrations/2023_12_02_031016_create_follows_table.php
+++ b/database/migrations/2023_12_02_031016_create_follows_table.php
@@ -29,6 +29,6 @@ return new class extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('follow_users');
+        Schema::dropIfExists('follows');
     }
 };


### PR DESCRIPTION
デプロイの際に発生したエラーのため、3度目のフォロー機能修正。

具体的には、
・マイグレーション時に削除されるテーブル名を修正。