### PR TITLE
デプロイのフォロー機能修正4

### DIFF
--- a/database/migrations/2023_12_02_031016_create_follows_table.php
+++ b/database/migrations/2023_12_02_031016_create_follows_table.php
@@ -14,11 +14,11 @@ return new class extends Migration
     public function up()
     {   
         Schema::create('follows', function (Blueprint $table) {
+            $table->primary(['follower_id', 'followee_id']);
             $table->foreignId('follower_id')->constraint('users')
                 ->cascadeOnUpdate()->cascadeOnDelete();
             $table->foreignId('followee_id')->constraint('users')
                 ->cascadeOnUpdate()->cascadeOnDelete();
-            $table->primary(['follower_id', 'followee_id']);
         });
     }
 


### PR DESCRIPTION
デプロイのフォロー機能でエラーが出たため解消

具体的には、
・フォローマイグレーションファイルの複合キーが、始めに読み込まれるようにした。